### PR TITLE
Refactor for `Map` as preparation for using MapGenerator in runtime

### DIFF
--- a/dependency/proto/Message2Clients.proto
+++ b/dependency/proto/Message2Clients.proto
@@ -100,11 +100,13 @@ message MessageOfHome
 
 message MessageOfMap
 {
+    uint32 height = 1;
+    uint32 width = 2;
     message Row
     {
-        repeated PlaceType col = 1;
+        repeated PlaceType cols = 1;
     }
-    repeated Row row = 2;
+    repeated Row rows = 3;
 }
 
 message MessageOfTeam

--- a/dependency/proto/Message2Server.proto
+++ b/dependency/proto/Message2Server.proto
@@ -3,6 +3,8 @@ syntax = "proto3";
 package protobuf;
 import "MessageType.proto";
 
+message NullRequest {}
+
 message IDMsg
 {
     int64 player_id = 1;

--- a/dependency/proto/Services.proto
+++ b/dependency/proto/Services.proto
@@ -6,16 +6,17 @@ import "Message2Server.proto";
 
 service AvailableService
 {
-    rpc TryConnection(IDMsg) returns(BoolRes);
+    rpc TryConnection(IDMsg) returns (BoolRes);
     // 游戏开局调用一次的服务
-    rpc AddPlayer(PlayerMsg) returns(stream MessageToClient); // 连接上后等待游戏开始，server会定时通过该服务向所有client发送消息。
+    rpc AddPlayer(PlayerMsg) returns (stream MessageToClient); // 连接上后等待游戏开始，server会定时通过该服务向所有client发送消息。
+    rpc GetMap(NullRequest) returns (MessageOfMap);
     // 游戏过程中玩家执行操作的服务   
     // 船
-    rpc Move(MoveMsg) returns (MoveRes);             //移动
-    rpc Recover(IDMsg) returns (BoolRes);            //回复
-    rpc Produce(TargetMsg) returns (BoolRes);       //开采
-    rpc Rebuild(ConstructMsg) returns (BoolRes);       //给建筑回血     
-    rpc Construct(ConstructMsg) returns (BoolRes);  //修建建筑
+    rpc Move(MoveMsg) returns (MoveRes);            // 移动
+    rpc Recover(IDMsg) returns (BoolRes);           // 回复
+    rpc Produce(TargetMsg) returns (BoolRes);       // 开采
+    rpc Rebuild(ConstructMsg) returns (BoolRes);    // 给建筑回血     
+    rpc Construct(ConstructMsg) returns (BoolRes);  // 修建建筑
     rpc Attack(AttackMsg) returns (BoolRes);        // 攻击
     rpc Send(SendMsg) returns (BoolRes);            // 传递信息
     // 大本营

--- a/logic/Client/MainPage.xaml.cs
+++ b/logic/Client/MainPage.xaml.cs
@@ -59,7 +59,7 @@ namespace Client
                 {
                     for (int j = 0; j < 50; j++)
                     {
-                        map[i, j] = Convert.ToInt32(obj.Row[i].Col[j]) + 4;//与proto一致
+                        map[i, j] = Convert.ToInt32(obj.Rows[i].Cols[j]) + 4; // 与proto一致
                     }
                 }
             }

--- a/logic/GameClass/GameObj/Map/Map.cs
+++ b/logic/GameClass/GameObj/Map/Map.cs
@@ -5,6 +5,7 @@ using Preparation.Utility;
 using System;
 using GameClass.GameObj.Areas;
 using System.Linq;
+using MapGenerator;
 
 namespace GameClass.GameObj
 {
@@ -12,6 +13,10 @@ namespace GameClass.GameObj
     {
         public Dictionary<GameObjType, IList<IGameObj>> GameObjDict { get; }
         public Dictionary<GameObjType, ReaderWriterLockSlim> GameObjLockDict { get; }
+        private readonly uint height;
+        public uint Height => height;
+        private readonly uint width;
+        public uint Width => width;
         public readonly uint[,] protoGameMap;
         public uint[,] ProtoGameMap => protoGameMap;
 
@@ -305,7 +310,7 @@ namespace GameClass.GameObj
                 GameObjLockDict[gameObj.Type].ExitWriteLock();
             }
         }
-        public Map(uint[,] mapResource)
+        public Map(MapStruct mapResource)
         {
             GameObjDict = [];
             GameObjLockDict = [];
@@ -317,14 +322,15 @@ namespace GameClass.GameObj
                     GameObjLockDict.Add(idx, new ReaderWriterLockSlim());
                 }
             }
-            protoGameMap = new uint[mapResource.GetLength(0), mapResource.GetLength(1)];
-            Array.Copy(mapResource, protoGameMap, mapResource.Length);
-            for (int i = 0; i < GameData.MapRows; ++i)
+            height = mapResource.height;
+            width = mapResource.width;
+            protoGameMap = mapResource.map;
+            for (int i = 0; i < height; ++i)
             {
-                for (int j = 0; j < GameData.MapCols; ++j)
+                for (int j = 0; j < width; ++j)
                 {
                     bool hasWormhole = false;
-                    switch ((PlaceType)mapResource[i, j])
+                    switch ((PlaceType)mapResource.map[i, j])
                     {
                         case PlaceType.Resource:
                             Add(new Resource(GameData.GetCellCenterPos(i, j)));

--- a/logic/GameClass/GameObj/Map/MapInfo.cs
+++ b/logic/GameClass/GameObj/Map/MapInfo.cs
@@ -1,13 +1,9 @@
-﻿namespace GameClass.GameObj
+﻿using MapGenerator;
+
+namespace GameClass.GameObj
 {
     public static class MapInfo
     {
-        /// <summary>
-        /// 检测物体在哪；不能返回invisible。
-        /// </summary>
-        /// <param name="obj"></param>
-        //// <returns></returns>
-
         /// <summary>
         /// 50*50
         /// </summary>
@@ -65,5 +61,11 @@
             {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}
         };
         public static uint[,] birthPoints = new uint[2, 2] { { 3, 46 }, { 46, 3 } };
+        public static MapStruct defaultMapStruct = new()
+        {
+            height = 50,
+            width = 50,
+            map = defaultMap
+        };
     }
 }

--- a/logic/Gaming/Game.cs
+++ b/logic/Gaming/Game.cs
@@ -1,5 +1,6 @@
 using GameClass.GameObj;
 using GameClass.GameObj.Areas;
+using MapGenerator;
 using Preparation.Interface;
 using Preparation.Utility;
 using System.Collections.Generic;
@@ -248,7 +249,7 @@ namespace Gaming
                 }
             }
         }
-        public Game(uint[,] mapResource, int numOfTeam)
+        public Game(MapStruct mapResource, int numOfTeam)
         {
             gameMap = new(mapResource);
             shipManager = new(gameMap);

--- a/logic/Server/ArgumentOptions.cs
+++ b/logic/Server/ArgumentOptions.cs
@@ -1,6 +1,4 @@
 ﻿using CommandLine;
-using CommandLine.Text;
-using Newtonsoft.Json;
 
 namespace Server
 {

--- a/logic/Server/CopyInfo.cs
+++ b/logic/Server/CopyInfo.cs
@@ -1,9 +1,6 @@
-using Protobuf;
 using GameClass.GameObj;
 using Preparation.Utility;
-using Gaming;
-using Preparation.Interface;
-using System.Runtime.Versioning;
+using Protobuf;
 
 namespace Server
 {

--- a/logic/Server/GameServer.cs
+++ b/logic/Server/GameServer.cs
@@ -8,7 +8,7 @@ using Preparation.Utility;
 using Protobuf;
 using System.Collections.Concurrent;
 using Timothy.FrameRateTask;
-
+using Utility = Preparation.Utility;
 
 namespace Server
 {
@@ -25,7 +25,7 @@ namespace Server
         private List<MessageOfNews> currentNews = [];
         private SemaphoreSlim endGameSem = new(0);
         protected readonly Game game;
-        private uint spectatorMinPlayerID = 2023;
+        private readonly uint spectatorMinPlayerID = 2023;
         public int playerNum;
         public int TeamCount => options.TeamCount;
         protected long[][] communicationToGameID; // 通信用的ID映射到游戏内的ID，0指向队伍1，1指向队伍2，通信中0-2为民船，3-6为军用船，7为旗舰，8为大本营
@@ -174,7 +174,7 @@ namespace Server
                 }
             }
         }
-        private bool playerDeceased(int playerID)    //这里需要判断大本营deceased吗？
+        private bool PlayerDeceased(int playerID)    //这里需要判断大本营deceased吗？
         {
             game.GameMap.GameObjLockDict[GameObjType.Ship].EnterReadLock();
             try
@@ -212,7 +212,7 @@ namespace Server
             return score;
         }
 
-        private uint GetBirthPointIdx(long playerID)  // 获取出生点位置
+        private static uint GetBirthPointIdx(long playerID)  // 获取出生点位置
         {
             return (uint)playerID + 1; // ID从0-8,出生点从1-9
         }
@@ -243,30 +243,22 @@ namespace Server
             return msg;
         }
 
-        private static Protobuf.PlaceType IntToPlaceType(uint n) => n switch
-        {
-            0 => Protobuf.PlaceType.Space,
-            1 => Protobuf.PlaceType.Ruin,
-            2 => Protobuf.PlaceType.Shadow,
-            3 => Protobuf.PlaceType.Asteroid,
-            4 => Protobuf.PlaceType.Resource,
-            5 => Protobuf.PlaceType.Construction,
-            6 => Protobuf.PlaceType.Wormhole,
-            7 => Protobuf.PlaceType.HomePlace,
-            _ => Protobuf.PlaceType.NullPlaceType,
-        };
-        private MessageOfObj MapMsg(uint[,] map)
+        private static MessageOfObj MapMsg(uint[,] map)
         {
             MessageOfObj msgOfMap = new()
             {
                 MapMessage = new()
+                {
+                    Height = GameData.MapRows,
+                    Width = GameData.MapCols
+                }
             };
             for (int i = 0; i < GameData.MapRows; i++)
             {
-                msgOfMap.MapMessage.Row.Add(new MessageOfMap.Types.Row());
+                msgOfMap.MapMessage.Rows.Add(new MessageOfMap.Types.Row());
                 for (int j = 0; j < GameData.MapCols; j++)
                 {
-                    msgOfMap.MapMessage.Row[i].Col.Add(IntToPlaceType(map[i, j]));
+                    msgOfMap.MapMessage.Rows[i].Cols.Add(Transformation.PlaceTypeToProto((Utility.PlaceType)map[i, j]));
                 }
             }
             return msgOfMap;
@@ -300,7 +292,7 @@ namespace Server
                                     else
                                     {
                                         //2022-04-22 by LHR 十六进制编码地图方案（防止地图编辑员瞎眼x
-                                        map[i, j] = (uint)Preparation.Utility.MapEncoder.Hex2Dec(char.Parse(item));
+                                        map[i, j] = (uint)MapEncoder.Hex2Dec(char.Parse(item));
                                     }
                                     j++;
                                     if (j >= GameData.MapCols)

--- a/logic/Server/GameServer.cs
+++ b/logic/Server/GameServer.cs
@@ -1,9 +1,7 @@
 ﻿using GameClass.GameObj;
-using GameClass.GameObj.Areas;
 using Gaming;
 using MapGenerator;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using Playback;
 using Preparation.Utility;
 using Protobuf;
@@ -247,22 +245,19 @@ namespace Server
             return msg;
         }
 
-        private MessageOfObj MapMsg(uint[,] map)
+        private MessageOfMap MapMsg()
         {
-            MessageOfObj msgOfMap = new()
+            MessageOfMap msgOfMap = new()
             {
-                MapMessage = new()
-                {
-                    Height = game.GameMap.Height,
-                    Width = game.GameMap.Width
-                }
+                Height = game.GameMap.Height,
+                Width = game.GameMap.Width
             };
             for (int i = 0; i < game.GameMap.Height; i++)
             {
-                msgOfMap.MapMessage.Rows.Add(new MessageOfMap.Types.Row());
+                msgOfMap.Rows.Add(new MessageOfMap.Types.Row());
                 for (int j = 0; j < game.GameMap.Width; j++)
                 {
-                    msgOfMap.MapMessage.Rows[i].Cols.Add(Transformation.PlaceTypeToProto((Utility.PlaceType)map[i, j]));
+                    msgOfMap.Rows[i].Cols.Add(Transformation.PlaceTypeToProto((Utility.PlaceType)game.GameMap.ProtoGameMap[i, j]));
                 }
             }
             return msgOfMap;
@@ -325,7 +320,7 @@ namespace Server
                     game = new(mapResource, options.TeamCount);
                 }
             }
-            currentMapMsg = MapMsg(game.GameMap.ProtoGameMap);
+            currentMapMsg = new() { MapMessage = MapMsg() };
             playerNum = options.ShipCount + options.HomeCount;
             communicationToGameID = new long[TeamCount][];
             for (int i = 0; i < TeamCount; i++)

--- a/logic/Server/HttpSender.cs
+++ b/logic/Server/HttpSender.cs
@@ -1,8 +1,4 @@
-﻿using Newtonsoft.Json.Linq;
-using System;
-using System.Net;
-using System.Net.Http.Json;
-using System.Text;
+﻿using System.Net.Http.Json;
 
 namespace Server
 {

--- a/logic/Server/PlaybackServer.cs
+++ b/logic/Server/PlaybackServer.cs
@@ -1,6 +1,4 @@
-﻿using Gaming;
-using Grpc.Core;
-using Playback;
+﻿using Playback;
 using Protobuf;
 using System.Collections.Concurrent;
 using Timothy.FrameRateTask;

--- a/logic/Server/RpcServices.cs
+++ b/logic/Server/RpcServices.cs
@@ -212,7 +212,7 @@ namespace Server
         public override Task<BoolRes> Send(SendMsg request, ServerCallContext context)
         {
             var boolRes = new BoolRes();
-            if (request.PlayerId >= spectatorMinPlayerID || playerDeceased((int)request.PlayerId))
+            if (request.PlayerId >= spectatorMinPlayerID || PlayerDeceased((int)request.PlayerId))
             {
                 boolRes.ActSuccess = false;
                 return Task.FromResult(boolRes);

--- a/logic/Server/RpcServices.cs
+++ b/logic/Server/RpcServices.cs
@@ -165,6 +165,14 @@ namespace Server
             } while (game.GameMap.Timer.IsGaming);
         }
 
+        public override Task<MessageOfMap> GetMap(NullRequest request, ServerCallContext context)
+        {
+#if DEBUG
+            Console.WriteLine($"GetMap IP: {context.Peer}");
+#endif 
+            return Task.FromResult(MapMsg());
+        }
+
         public override Task<BoolRes> Attack(AttackMsg request, ServerCallContext context)
         {
 #if DEBUG
@@ -185,7 +193,6 @@ namespace Server
             boolRes.ActSuccess = game.Attack(gameID, request.Angle);
             return Task.FromResult(boolRes);
         }
-
 
         public override Task<MoveRes> Move(MoveMsg request, ServerCallContext context)
         {
@@ -352,7 +359,6 @@ namespace Server
             boolRes.ActSuccess = game.Recycle(gameID);
             return Task.FromResult(boolRes);
         }
-
 
         public override Task<BoolRes> InstallModule(InstallMsg request, ServerCallContext context)
         {


### PR DESCRIPTION
<!-- Before creating this pull request, check the questions below: -->  
<!-- 在提出这个 pull request 之前，请勾选下面的问题： -->

- [x] 您的代码是否能够编译通过？
- [x] 您是否检查了目前在 [pull requests](https://github.com/eesast/THUAI7/pulls) 中是否有与你的贡献功能相同的更改？
- [x] 您的贡献是否符合[贡献者代码协议](https://github.com/eesast/THUAI7/blob/dev/CODE_OF_CONDUCT.md)？
- [x] 您的贡献是否符合[开发规则](https://github.com/eesast/THUAI7#%E5%BC%80%E5%8F%91%E8%A7%84%E5%88%99)？  

Descriptions of this pull request:

<!-- If you have something to say about this pull request, delete the sentence 'No additional description.' below and add your description. -->
<!-- 如果你对这次的 pull request 有一些描述，请删除下面的句子“No additional description.”并加上你的描述。 -->

- Deeper using for `MapStruct`
  - Change ctor of `Map`
- Adjust the static method `MapMsg` to make it wider applicable
- Add `GetMap` in Services.proto
  - Client can now load the game map just before gaming, so that it will cut down the unnecessary calculation in gaming