### PR TITLE
feat(CAPI): :sparkles: add `guids_all` & fix `GetPlayerGUIDs`

### DIFF
--- a/CAPI/cpp/API/include/state.h
+++ b/CAPI/cpp/API/include/state.h
@@ -25,6 +25,7 @@ struct State
     std::shared_ptr<THUAI7::GameMap> mapInfo;
     std::shared_ptr<THUAI7::GameInfo> gameInfo;
     std::vector<int64_t> guids;
+    std::vector<int64_t> guids_all;
 };
 
 #endif

--- a/CAPI/cpp/API/src/logic.cpp
+++ b/CAPI/cpp/API/src/logic.cpp
@@ -821,11 +821,16 @@ void Logic::LoadBuffer(const protobuf::MessageToClient& message)
         bufferState->enemyShips.clear();
         bufferState->bullets.clear();
         bufferState->guids.clear();
+        bufferState->guids_all.clear();
         logger->info("Buffer cleared!");
         // 读取新的信息
         for (const auto& obj : message.obj_message())
             if (Proto2THUAI7::messageOfObjDict[obj.message_of_obj_case()] == THUAI7::MessageOfObj::ShipMessage)
-                bufferState->guids.push_back(obj.ship_message().guid());
+            {
+                bufferState->guids_all.push_back(obj.ship_message().guid());
+                if (obj.obj.ship_message().team_id() == teamID)
+                    bufferState->guids.push_back(obj.ship_message().guid());
+            }
         bufferState->gameInfo = Proto2THUAI7::Protobuf2THUAI7GameInfo(message.all_message());
         LoadBufferSelf(message);
         // 确保这是一个活着的船，否则会使用空指针

--- a/CAPI/python/PyAPI/State.py
+++ b/CAPI/python/PyAPI/State.py
@@ -14,6 +14,7 @@ class State:
         self.mapInfo = THUAI7.GameMap()
         self.gameInfo = THUAI7.GameInfo()
         self.guids = []
+        self.guids_all = []
 
     teamScore: int
     self: Union[THUAI7.Ship, THUAI7.Team]
@@ -31,3 +32,4 @@ class State:
     gameInfo: THUAI7.GameInfo
 
     guids: List[int]
+    guids_all: List[int]

--- a/CAPI/python/PyAPI/logic.py
+++ b/CAPI/python/PyAPI/logic.py
@@ -314,16 +314,14 @@ class Logic(ILogic):
             self.__bufferState.bullets.clear()
             self.__bufferState.bombedBullets.clear()
             self.__bufferState.guids.clear()
+            self.__bufferState.guids_all.clear()
             self.__logger.debug("Buffer cleared")
 
-            if self.__playerID != 0:
-                for obj in message.obj_message:
-                    if obj.WhichOneof("message_of_obj") == "ship_message":
+            for obj in message.obj_message:
+                if obj.WhichOneof("message_of_obj") == "ship_message":
+                    self.__bufferState.guids_all.append(obj.ship_message.guid)
+                    if obj.ship_message.team_id == self.__teamID:
                         self.__bufferState.guids.append(obj.ship_message.guid)
-            # else:
-            #     for obj in message.obj_message:
-            #         if obj.WhichOneof("message_of_obj") == "team_message":
-            #             self.__bufferState.guids.append(obj.team_message.guid)
 
             self.__bufferState.gameInfo = Proto2THUAI7.Protobuf2THUAI7GameInfo(
                 message.all_message


### PR DESCRIPTION
now players will see only the guids of their own team, but we can get all the guids through backdoor


<!-- Before creating this pull request, check the questions below: -->  
<!-- 在提出这个 pull request 之前，请勾选下面的问题： -->

- [x] 您的代码是否能够编译通过？
- [x] 您是否检查了目前在 [pull requests](https://github.com/eesast/THUAI7/pulls) 中是否有与你的贡献功能相同的更改？
- [x] 您的贡献是否符合[贡献者代码协议](https://github.com/eesast/THUAI7/blob/dev/CODE_OF_CONDUCT.md)？
- [x] 您的贡献是否符合[开发规则](https://github.com/eesast/THUAI7#%E5%BC%80%E5%8F%91%E8%A7%84%E5%88%99)？  

Descriptions of this pull request:

<!-- If you have something to say about this pull request, delete the sentence 'No additional description.' below and add your description. -->
<!-- 如果你对这次的 pull request 有一些描述，请删除下面的句子“No additional description.”并加上你的描述。 -->

No additional description.
